### PR TITLE
python package error in ubuntu quickfix

### DIFF
--- a/playbooks/piku.yml
+++ b/playbooks/piku.yml
@@ -31,7 +31,7 @@
 
     - name: Install Debian Packages
       apt:
-        pkg: ['bc', 'git', 'build-essential', 'libpcre3-dev', 'zlib1g-dev', 'python', 'python3', 'python3-pip', 'python3-click', 'python3-dev', 'python3-virtualenv', 'python3-setuptools', 'nginx', 'acl', 'uwsgi-core', 'uwsgi-plugin-python3', 'nodeenv']
+        pkg: ['bc', 'git', 'build-essential', 'libpcre3-dev', 'zlib1g-dev', 'python-is-python3', 'python3', 'python3-pip', 'python3-click', 'python3-dev', 'python3-virtualenv', 'python3-setuptools', 'nginx', 'acl', 'uwsgi-core', 'uwsgi-plugin-python3', 'nodeenv']
         update_cache: true
         state: present
 


### PR DESCRIPTION
quickfix for case when bootstraping fails due to "python" is not a deb package in ubuntu